### PR TITLE
fixed DataLayers URL parameter

### DIFF
--- a/server/safers/data/views.py
+++ b/server/safers/data/views.py
@@ -93,7 +93,7 @@ class DataLayerListView(views.APIView):
                 "bbox": "{bbox}",
                 "width": 256,
                 "height": 256,
-                "fmt": "image/png",
+                "format": "image/png",
             },
             safe="{}",
         )


### PR DESCRIPTION
Accidentally used "fmt" instead of "format" in the generated URL for leaf-nodes of the DataLayers API Response. (This was a holdover from when I was proxying geoserver access through the Dashboard API and therefore couldn't use the "format" parameter name b/c it was already used as a query parameter by DRF.)
