### PR TITLE
feat(backend): made most alert serializer fields read-only

### DIFF
--- a/server/safers/alerts/serializers.py
+++ b/server/safers/alerts/serializers.py
@@ -37,7 +37,9 @@ class AlertSerializer(serializers.ModelSerializer):
             "message",
         )
 
-    geometry = AlertGeometrySerializer(many=True, source="geometries")
+    geometry = AlertGeometrySerializer(
+        many=True, source="geometries", required=False
+    )
     center = serializers.SerializerMethodField()
     bounding_box = serializers.SerializerMethodField()
     message = serializers.JSONField(write_only=True)
@@ -69,3 +71,42 @@ class AlertSerializer(serializers.ModelSerializer):
             instance.unvalidate()
         alert = super().update(instance, validated_data)
         return alert
+
+
+class AlertViewSetSerializer(AlertSerializer):
+    """
+    The serializer used by the AlertViewSet.  This is different from the default serializer which is used by
+    RMQ.  The latter allows all fields to be updated.  The former only allows "information" & "type"
+    """
+    class Meta:
+        model = Alert
+        fields = (
+            "id",
+            "type",
+            "timestamp",
+            "status",
+            "source",
+            "scope",
+            "category",
+            "event",
+            "urgency",
+            "severity",
+            "certainty",
+            "description",
+            "geometry",
+            "center",
+            "bounding_box",
+        )
+        extra_kwargs = {
+            "timestamp": {"read_only": True},
+            "status": {"read_only": True},
+            "source": {"read_only": True},
+            "scope": {"read_only": True},
+            "category": {"read_only": True},
+            "event": {"read_only": True},
+            "urgency": {"read_only": True},
+            "severity": {"read_only": True},
+            "certainty": {"read_only": True},
+            "description": {"read_only": True},
+            "geometry": {"read_only": True},
+        }  # yapf: disable

--- a/server/safers/core/filters.py
+++ b/server/safers/core/filters.py
@@ -65,6 +65,27 @@ class CharInFilter(filters.BaseInFilter, filters.CharFilter):
     pass
 
 
+class DefaultFilterBackend(filters.DjangoFilterBackend):
+    """
+    alternative way of providing default values to filters
+    as per https://github.com/astrosat/safers-gateway/issues/45
+    (since DefaultFilterSetMixin might not be the best idea)
+    """
+    @property
+    def default_filterset_kwargs(self):
+        raise NotImplementedError(
+            "default_filterset_kwargs must be implemented"
+        )
+
+    def get_filterset_kwargs(self, request, queryset, view):
+        self.view = view
+        kwargs = super().get_filterset_kwargs(request, queryset, view)
+        data = kwargs["data"].copy()
+        data.update(self.default_filterset_kwargs)
+        kwargs["data"] = data
+        return kwargs
+
+
 class DefaultFilterSetMixin():
     """
     allows me to provide "initial" values as defaults


### PR DESCRIPTION
Subclassed `AlertSerializer` into another class to use w/ `AlertViewSet` where most fields are read-only.