### PR TITLE
feat(backend): added timestamp dictionary to datalayers response

### DIFF
--- a/server/safers/data/views/views_datalayers.py
+++ b/server/safers/data/views/views_datalayers.py
@@ -1,4 +1,5 @@
 import requests
+from collections import OrderedDict
 from datetime import datetime, timedelta
 from urllib.parse import quote_plus, urlencode, urljoin
 
@@ -40,11 +41,11 @@ _data_layer_schema = openapi.Schema(
                     "id": "1.1.1.1",
                     "text": "2022-04-28T12:15:20Z",
                     "info_url": "http://localhost:8000/api/data/layers/metadata/02bae14e-c24a-4264-92c0-2cfbf7aa65f5",
-                    "urls": [
-                      "https://geoserver-test.safers-project.cloud/geoserver/ermes/wms?time=2022-04-28T12%3A15%3A20Z&layers=ermes%3A33101_t2m_33001_b7aa380a-20fc-41d2-bfbc-a6ca73310f4d&service=WMS&request=GetMap&srs=EPSG%3A4326&bbox={bbox}&width=256&height=256&format=image%2Fpng",
-                      "https://geoserver-test.safers-project.cloud/geoserver/ermes/wms?time=2022-04-28T13%3A15%3A20Z&layers=ermes%3A33101_t2m_33001_b7aa380a-20fc-41d2-bfbc-a6ca73310f4d&service=WMS&request=GetMap&srs=EPSG%3A4326&bbox={bbox}&width=256&height=256&format=image%2Fpng",
-                      "https://geoserver-test.safers-project.cloud/geoserver/ermes/wms?time=2022-04-28T14%3A15%3A20Z&layers=ermes%3A33101_t2m_33001_b7aa380a-20fc-41d2-bfbc-a6ca73310f4d&service=WMS&request=GetMap&srs=EPSG%3A4326&bbox={bbox}&width=256&height=256&format=image%2Fpng",
-                    ]
+                    "urls": {
+                      "2022-04-28T12:15:20Z": "https://geoserver-test.safers-project.cloud/geoserver/ermes/wms?time=2022-04-28T12%3A15%3A20Z&layers=ermes%3A33101_t2m_33001_b7aa380a-20fc-41d2-bfbc-a6ca73310f4d&service=WMS&request=GetMap&srs=EPSG%3A4326&bbox={bbox}&width=256&height=256&format=image%2Fpng",
+                      "2022-04-28T13:15:20Z": "https://geoserver-test.safers-project.cloud/geoserver/ermes/wms?time=2022-04-28T13%3A15%3A20Z&layers=ermes%3A33101_t2m_33001_b7aa380a-20fc-41d2-bfbc-a6ca73310f4d&service=WMS&request=GetMap&srs=EPSG%3A4326&bbox={bbox}&width=256&height=256&format=image%2Fpng",
+                      "2022-04-28T14:15:20Z": "https://geoserver-test.safers-project.cloud/geoserver/ermes/wms?time=2022-04-28T14%3A15%3A20Z&layers=ermes%3A33101_t2m_33001_b7aa380a-20fc-41d2-bfbc-a6ca73310f4d&service=WMS&request=GetMap&srs=EPSG%3A4326&bbox={bbox}&width=256&height=256&format=image%2Fpng",
+                    }
                 }
               ]
             }
@@ -170,17 +171,23 @@ class DataLayerView(views.APIView):
                     "info": data_type_info.get(str(layer.get("dataTypeId"))),
                     "children": [
                       {
+                        # "data_type": detail.get("dataTypeId"),
                         "id": f"{i}.{j}.{k}.{l}",
                         "text": detail["created_At"],
                         "info_url": metadata_url.format(metadata_id=detail.get("metadata_Id")),
-                        "urls": [
-                          geoserver_url.format(
-                            name=quote_plus(detail["name"]),
-                            time=quote_plus(timestamp),
-                            bbox="{bbox}",
-                          )
-                          for timestamp in detail.get("timestamps", [])
-                        ]
+                        "urls": OrderedDict(
+                          [
+                            (
+                                timestamp,
+                                geoserver_url.format(
+                                  name=quote_plus(detail["name"]),
+                                  time=quote_plus(timestamp),
+                                  bbox="{bbox}",
+                                )
+                            )
+                            for timestamp in detail.get("timestamps", [])
+                          ]
+                        )
                       }
                       for l, detail in enumerate(
                         sorted(layer.get("details"), key=lambda x: x.get("created_At"), reverse=True) or [],


### PR DESCRIPTION
Rather than a simple list of urls for each layer of a timeseries, the API now returns an ordered dictionary keyed on timestamp.  This allows the frontend to use the timestamp as the label of a slider.