### PR TITLE
feat(backend): filtered existing camera media objects by is_detected

### DIFF
--- a/server/safers/cameras/utils.py
+++ b/server/safers/cameras/utils.py
@@ -105,9 +105,10 @@ def process_messages(message_body, **kwargs):
             # maybe create alert...
             if camera_media.is_detected:
 
-                most_recent_camera_media_detected_timestamp = camera.media.exclude(
-                    pk=camera_media.pk
-                ).order_by("timestamp").values_list("timestamp", flat=True).last()  # yapf: disable
+                most_recent_camera_media_detected_timestamp = camera.media.detected(
+                ).exclude(pk=camera_media.pk).order_by("timestamp").values_list(
+                    "timestamp", flat=True
+                ).last()  # yapf: disabled
 
                 if not most_recent_camera_media_detected_timestamp or (
                     camera_media.timestamp -


### PR DESCRIPTION
When deciding whether or not a camera event should trigger an event, compare the date against the last _detected_ camera media.