### PR TITLE
feat(backend): ensured the initial value of default_date is False

### DIFF
--- a/server/safers/alerts/views.py
+++ b/server/safers/alerts/views.py
@@ -107,7 +107,7 @@ class AlertFilterSet(DefaultFilterSetMixin, filters.FilterSet):
         field_name="timestamp", lookup_expr="date__lte"
     )
     default_date = filters.BooleanFilter(
-        initial=True,
+        initial=False,
         help_text=_(
             "If default_date is True and no end_date is provided then the current date will be used and if no start_date is provided then 3 days previous will be used; "
             "If default_date is False and no end_date or start_date is used then no date filters will be passed to the API."

--- a/server/safers/cameras/views/views_cameramedia.py
+++ b/server/safers/cameras/views/views_cameramedia.py
@@ -87,7 +87,7 @@ class CameraMediaFilterSet(DefaultFilterSetMixin, filters.FilterSet):
         field_name="timestamp", lookup_expr="date__lte"
     )
     default_date = filters.BooleanFilter(
-        initial=True,
+        initial=False,
         help_text=_(
             "If default_date is True and no end_date is provided then the current date will be used and if no start_date is provided then 3 days previous will be used; "
             "If default_date is False and no end_date or start_date is used then no date filters will be passed to the API."

--- a/server/safers/chatbot/serializers/serializers_reports.py
+++ b/server/safers/chatbot/serializers/serializers_reports.py
@@ -106,7 +106,6 @@ class ReportViewSerializer(serializers.Serializer):
     )
 
     default_date = serializers.BooleanField(
-        # default=True,
         default=False,
         required=False,
         help_text=_(

--- a/server/safers/data/serializers/serializers_datalayers.py
+++ b/server/safers/data/serializers/serializers_datalayers.py
@@ -76,22 +76,15 @@ class DataLayerSerializer(serializers.Serializer):
     )
     order = serializers.ChoiceField(choices=OrderType.choices, required=False)
 
-    default_start = serializers.BooleanField(
-        default=True,
+    default_date = serializers.BooleanField(
+        default=False,
         required=False,
         help_text=_(
-            "If default_start is True and no start is provided the default start (now) will be used; "
-            "If default_start is False and no start is provided then no start filter will be passed to the API"
+            "If default_date is True and no start/end is provided the default start/end (now / 3 days prior) will be used; "
+            "If default_date is False and no start/end is provided then no start/end filters will be passed to the API"
         )
     )
-    default_end = serializers.BooleanField(
-        default=True,
-        required=False,
-        help_text=_(
-            "If default_end is True and no end is provided the default start (3 days prior to now) will be used; "
-            "If default_end is False and no end is provided then no end filter will be passed to the API"
-        )
-    )
+
     default_bbox = serializers.BooleanField(
         default=True,
         required=False,

--- a/server/safers/data/views/views_datalayers.py
+++ b/server/safers/data/views/views_datalayers.py
@@ -114,10 +114,10 @@ class DataLayerView(views.APIView):
             default_bbox = user.default_aoi.geometry.extent
             data["bbox"] = ",".join(map(str, default_bbox))
 
-        if data.pop("default_start") and "start" not in data:
+        default_date = data.pop("default_date")
+        if default_date and "start" not in data:
             data["start"] = timezone.now() - timedelta(days=3)
-
-        if data.pop("default_end") and "end" not in data:
+        if default_date and "end" not in data:
             data["end"] = timezone.now()
 
         return data

--- a/server/safers/events/views.py
+++ b/server/safers/events/views.py
@@ -96,7 +96,7 @@ class EventFilterSet(DefaultFilterSetMixin, filters.FilterSet):
         field_name="start_date", lookup_expr="date__lte"
     )
     default_date = filters.BooleanFilter(
-        initial=True,
+        initial=False,
         help_text=_(
             "If default_date is True and no end_date is provided then the current date will be used and if no start_date is provided then 3 days previous will be used; "
             "If default_date is False and no end_date or start_date is used then no date filters will be passed to the API."

--- a/server/safers/notifications/views.py
+++ b/server/safers/notifications/views.py
@@ -92,7 +92,7 @@ class NotificationFilterSet(DefaultFilterSetMixin, filters.FilterSet):
         field_name="timestamp", lookup_expr="date__lte"
     )
     default_date = filters.BooleanFilter(
-        initial=True,
+        initial=False,
         help_text=_(
             "If default_date is True and no end_date is provided then the current date will be used and if no start_date is provided then 3 days previous will be used; "
             "If default_date is False and no end_date or start_date is used then no date filters will be passed to the API."

--- a/server/safers/social/serializers/serializers_tweets.py
+++ b/server/safers/social/serializers/serializers_tweets.py
@@ -68,22 +68,15 @@ class TweetViewSerializer(serializers.Serializer):
         input_formats=TweetSerializerDateTimeFormats, required=False
     )
 
-    default_start = serializers.BooleanField(
-        default=True,
+    default_date = serializers.BooleanField(
+        default=False,
         required=False,
         help_text=_(
-            "If default_start is True and no start is provided the default start (now) will be used; "
-            "If default_start is False and no start is provided then no start filter will be passed to the API"
+            "If default_date is True and no start/end is provided the default start/end (now / 3 days prior) will be used; "
+            "If default_date is False and no start is provided then no start/end filters will be passed to the API"
         )
     )
-    default_end = serializers.BooleanField(
-        default=True,
-        required=False,
-        help_text=_(
-            "If default_end is True and no end is provided the default start (3 days prior to now) will be used; "
-            "If default_end is False and no end is provided then no end filter will be passed to the API"
-        )
-    )
+
     default_bbox = serializers.BooleanField(
         default=True,
         required=False,

--- a/server/safers/social/views/views_tweets.py
+++ b/server/safers/social/views/views_tweets.py
@@ -56,10 +56,10 @@ class TweetView(views.APIView):
 
     def update_default_data(self, data):
 
-        if data.pop("default_start") and "start" not in data:
+        default_date = data.pop("default_date")
+        if default_date and "start" not in data:
             data["start"] = timezone.now() - settings.SAFERS_DEFAULT_TIMERANGE
-
-        if data.pop("default_end") and "end" not in data:
+        if default_date and "end" not in data:
             data["end"] = timezone.now()
 
         if data.pop("default_bbox") and "bbox" not in data:


### PR DESCRIPTION
If `default_date` is not provided by the frontend, then it will have a default value of False instead of True.  This means that _only_ the explicit `start`/`end` parameters passed by the frontend will be used for date filtering.