### PR TITLE
feat(backend): exclude on-demand layers from the operational DataLayer

### DIFF
--- a/server/safers/data/serializers/serializers_datalayers.py
+++ b/server/safers/data/serializers/serializers_datalayers.py
@@ -28,7 +28,7 @@ class DataLayerSerializer(serializers.Serializer):
         "bbox": "Bbox",
         "start": "Start",
         "end": "End",
-        "include_map_requests": "InclueMapRequests",
+        "include_map_requests": "IncludeMapRequests",
     }
 
     n_layers = serializers.IntegerField(


### PR DESCRIPTION
API

The operational `DataLayer` API proxies a generic API that can include both operational and on-demand layers; this PR adds a flag to the proxy request to exclude on-demand layers.