### PR TITLE
chore(backend): fixed db migration error

### DIFF
--- a/server/safers/chatbot/migrations/0007_auto_20220816_1554.py
+++ b/server/safers/chatbot/migrations/0007_auto_20220816_1554.py
@@ -14,26 +14,47 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='report',
             name='hazard',
-            field=models.CharField(blank=True, choices=[('Avalanche', 'Avalanche'), ('Earthquake', 'Earthquake'), ('Fire', 'Fire'), ('Flood', 'Flood'), ('Landslide', 'Landslide'), ('Storm', 'Storm'), ('Weather', 'Weather'), ('Subsidence', 'Subsidence')], default='Fire', max_length=128, null=True),
-        ),
-        migrations.AlterField(
-            model_name='report',
-            name='id',
-            field=models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID'),
+            field=models.CharField(
+                blank=True,
+                choices=[('Avalanche', 'Avalanche'),
+                         ('Earthquake', 'Earthquake'), ('Fire', 'Fire'),
+                         ('Flood', 'Flood'), ('Landslide', 'Landslide'),
+                         ('Storm', 'Storm'), ('Weather', 'Weather'),
+                         ('Subsidence', 'Subsidence')],
+                default='Fire',
+                max_length=128,
+                null=True
+            ),
         ),
         migrations.AlterField(
             model_name='report',
             name='media',
-            field=models.JSONField(default=list, validators=[safers.chatbot.models.models_reports.validate_media]),
+            field=models.JSONField(
+                default=list,
+                validators=[
+                    safers.chatbot.models.models_reports.validate_media
+                ]
+            ),
         ),
         migrations.AlterField(
             model_name='report',
             name='reporter',
-            field=models.JSONField(default=dict, validators=[safers.chatbot.models.models_reports.validate_reporter]),
+            field=models.JSONField(
+                default=dict,
+                validators=[
+                    safers.chatbot.models.models_reports.validate_reporter
+                ]
+            ),
         ),
         migrations.AlterField(
             model_name='report',
             name='source',
-            field=models.CharField(blank=True, choices=[('Chatbot', 'Chatbot')], default='Chatbot', max_length=64, null=True),
+            field=models.CharField(
+                blank=True,
+                choices=[('Chatbot', 'Chatbot')],
+                default='Chatbot',
+                max_length=64,
+                null=True
+            ),
         ),
     ]

--- a/server/safers/chatbot/models/models_reports.py
+++ b/server/safers/chatbot/models/models_reports.py
@@ -86,6 +86,10 @@ class Report(gis_models.Model):
 
     PRECISION = 12
 
+    id = models.UUIDField(
+        primary_key=True, default=uuid.uuid4, editable=False
+    )  # TODO: figure out how to remove this field w/out generating 'ProgrammingError: cannot cast type uuid to bigint'
+
     report_id = models.CharField(
         max_length=128, unique=True, blank=False, null=False
     )


### PR DESCRIPTION
Could not delete unused "id" `uuid` field b/c it would be replaced by the standard `bigint` field and there is no automated way to migrate from one to the other in Postgres.