### PR TITLE
feat(backend): added defensive code for configure management command

### DIFF
--- a/server/safers/core/management/commands/configure.py
+++ b/server/safers/core/management/commands/configure.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from django.core import management
 from django.core.management.base import BaseCommand, CommandError
 
+from safers.core.models import SiteProfile
+
 
 def load_fixture(app_config, fixture_name):
     fixture_path = os.path.join(app_config.path, "fixtures", fixture_name)
@@ -77,7 +79,12 @@ class Command(BaseCommand):
 
             site_code = options["site_code"]
             if site_code:
-                current_site_profile = get_current_site(None).profile
+                current_site = get_current_site(None)
+                if not current_site:
+                    raise CommandError(
+                        "Unable to assign site_code as there is no current site instance."
+                    )
+                current_site_profile, _ = SiteProfile.objects.get_or_create(site=current_site)
                 current_site_profile.code = site_code
                 current_site_profile.save()
                 self.stdout.write("updated site_profile code")


### PR DESCRIPTION
Added defensive code in configure management command in case `Site` or `SiteProfile` does not exist.