### PR TITLE
feat(backend): set mission status

### DIFF
--- a/server/safers/chatbot/serializers/serializers_missions.py
+++ b/server/safers/chatbot/serializers/serializers_missions.py
@@ -72,7 +72,7 @@ class MissionCreateSerializer(gis_serializers.GeoFeatureModelSerializer):
             "end",
             "organizationId",
             "source",
-            "status",  # "reports",
+            "currentStatus",  # "reports",
             "duration",
             "geometry",
         )
@@ -88,6 +88,10 @@ class MissionCreateSerializer(gis_serializers.GeoFeatureModelSerializer):
 
     organizationId = serializers.SerializerMethodField(
         method_name="get_organization_id"
+    )
+
+    currentStatus = serializers.CharField(
+        source="status", default=MissionStatusTypes.CREATED
     )
 
     duration = serializers.SerializerMethodField()

--- a/server/safers/chatbot/views/views_missions.py
+++ b/server/safers/chatbot/views/views_missions.py
@@ -99,8 +99,7 @@ class MissionListView(MissionView):
                 end_inclusive=data["duration"].get(
                     "upperBoundIsInclusive", False
                 ),
-                # TODO: PROXY IS SENDING A NUMBER - I NEED TO MAP THAT TO ONE OF MissionStatusType.choices
-                # status=data.get("currentStatus"),
+                status=data.get("currentStatus"),
                 reports=[{
                     "id": report.get("id"),
                     "name": f"Report {report.get('id')}",
@@ -125,7 +124,6 @@ class MissionListView(MissionView):
         """
         create view
         """
-
         serializer = MissionCreateSerializer(
             data=request.data,
             context=self.get_serializer_context(),


### PR DESCRIPTION
Set mission status correctly when creating a mission; the chatbot API uses the key "currentStatus" while the dashboard uses "status".  I remapped these in the serializer (and ensured a newly-created mission has a default status f "Created").  Also, made sure to do the reverse mapping in the ListView.