### PR TITLE
feat(backend): made maprequest.category a property

### DIFF
--- a/server/safers/data/admin/admin_maprequests.py
+++ b/server/safers/data/admin/admin_maprequests.py
@@ -159,6 +159,7 @@ class MapRequestAdmin(gis_admin.GeoModelAdmin):
     list_display = (
         "request_id",
         "title",
+        "category",
         "created",
         "get_statuses_for_list_view",
     )

--- a/server/safers/data/serializers/serializers_maprequest.py
+++ b/server/safers/data/serializers/serializers_maprequest.py
@@ -104,6 +104,7 @@ class MapRequestDataTypeSerializer(serializers.ModelSerializer):
             "source",
             "domain",
             "status",
+            "message",
             "info",
             "proxy_details",
         )
@@ -146,7 +147,6 @@ class MapRequestSerializer(serializers.ModelSerializer):
         list_serializer_class = MapRequestListSerializer
 
     request_id = serializers.CharField(read_only=True)
-    category = serializers.SerializerMethodField()
     layers = MapRequestDataTypeSerializer(
         many=True, read_only=True, source="map_request_data_types"
     )
@@ -164,14 +164,6 @@ class MapRequestSerializer(serializers.ModelSerializer):
         default=SwaggerCurrentUserDefault(),
         queryset=get_user_model().objects.all(),
     )
-
-    def get_category(self, obj):
-        """
-        all MapRequests DataTypes have the same group (which the dashboard calls "category")
-        """
-        group = obj.data_types.values_list("group", flat=True).first()
-        if group:
-            return group.title()
 
     def validate_data_types(self, values):
         data_types_groups = set([v.group for v in values])

--- a/server/safers/data/views/views_maprequests.py
+++ b/server/safers/data/views/views_maprequests.py
@@ -46,6 +46,7 @@ _map_request_schema = openapi.Schema(
                 "info": "string",
                 "info_url": None,
                 "status": "PROCESSING",
+                "message": None,
             }
         ]
     }
@@ -83,6 +84,7 @@ _map_request_list_schema = openapi.Schema(
                             "source": "string",
                             "domain": "string",
                             "status": "string",
+                            "message": None,
                             "info": None,
                             "info_url": "url",
                             "metadata_url": "url",


### PR DESCRIPTION
Made maprequest.category a property rather than a calculated serializer field.  This means I can access it via the Django Admin, which is useful.  Also ensured that a request.layer.message is serialized.