### PR TITLE
chore(backend): prevent GEOSIntersects: TopologyException: side location conflict errors

### DIFF
--- a/server/safers/alerts/models.py
+++ b/server/safers/alerts/models.py
@@ -206,7 +206,7 @@ class Alert(models.Model):
         serial_number = f"S{self.sequence_number:0>5}"
 
         country = Country.objects.filter(
-            # geometry__intersects=self.geometry_collection  # TODO: if geometry_collection is malformed can potentiall get "GEOSIntersects: TopologyException: side location conflict"
+            # geometry__intersects=self.geometry_collection  # TODO: if geometry_collection is malformed can potentially get "GEOSIntersects: TopologyException: side location conflict"
             geometry__intersects=self.center
         ).first()
 


### PR DESCRIPTION
This happens when the alert.geometry_collection is somehow invalid.  I haven't figured out how that happens yet.  But using the alert.center instead of the complete geometry to work out which country it is in is probably good enough.