### PR TITLE
feat(backend): refactored check to validate that citizen users have no organization

### DIFF
--- a/server/safers/users/serializers/serializers_users.py
+++ b/server/safers/users/serializers/serializers_users.py
@@ -80,9 +80,9 @@ class UserSerializer(UserSerializerLite):
 
     def validate(self, data):
         validated_data = super().validate(data)
-
-        if (validated_data["organization"] is not None
-           ) and (validated_data["role"].name.lower() == "citizen"):
+        organziation = validated_data.get("organization")
+        role = validated_data.get("role")
+        if organziation and role and role.name.lower() == "citizen":
             raise serializers.ValidationError(
                 "A citizen must not belong to an organization."
             )

--- a/server/safers/users/views/views_oauth2.py
+++ b/server/safers/users/views/views_oauth2.py
@@ -188,7 +188,7 @@ class RegisterView(GenericAPIView):
             },
             "user": {
                 "email": serializer.validated_data["email"],
-                "username": serializer.validated_data["email"],
+                "username": serializer.validated_data["email"].strip("@")[0],
                 "password": serializer.validated_data["password"],
                 "firstName": serializer.validated_data["first_name"],
                 "lastName": serializer.validated_data["last_name"],


### PR DESCRIPTION
Refactored check to validate that citizen users have no organization since the request body will not always include those details (for example, when setting an AOI).

Also ensured that username passed to FusionAuth only includes the bit before the "@" of a user's email address.