### PR TITLE
feat(backend): added code to handle the case where the GetLayers API has missing data

### DIFF
--- a/server/safers/data/views/views_maprequests.py
+++ b/server/safers/data/views/views_maprequests.py
@@ -296,10 +296,10 @@ class MapRequestViewSet(
         # proxy_details is a dict of dicts: "request_id" followed by "data_type_id"
         # it is passed as context to the serializer below to add links, etc. to the model_serializer data
         proxy_details = defaultdict(dict)
-        for group in proxy_content.get("layerGroups", []):
-            for sub_group in group.get("subGroups", []):
-                for layer in sub_group.get("layers", []):
-                    for detail in layer.get("details", []):
+        for group in proxy_content.get("layerGroups") or []:
+            for sub_group in group.get("subGroups") or []:
+                for layer in sub_group.get("layers") or []:
+                    for detail in layer.get("details") or []:
                         request_id = detail.get("mapRequestCode")
                         if request_id in map_request_ids:
                             data_type_id = str(layer["dataTypeId"])


### PR DESCRIPTION
The data returned by GetLayers is a nested list of dictionaries.  I naively assumed that if there is no data in a child level then an empty list is used.  This is not true - instead the value None is used.  This PR replaces any Nones w/ an empty list.