### PR TITLE
feat(backend): don't serialize camera_media.message

### DIFF
--- a/server/safers/cameras/serializers/serializers_cameramedia.py
+++ b/server/safers/cameras/serializers/serializers_cameramedia.py
@@ -19,7 +19,6 @@ class CameraMediaSerializer(serializers.ModelSerializer):
             "distance",
             "geometry",
             "url",
-            "message",
             "favorite",  # note "favorite" is an annotated field
         )
 
@@ -45,7 +44,5 @@ class CameraMediaSerializer(serializers.ModelSerializer):
     # geometry = gis_serializers.GeometryField(
     #     precision=CameraMedia.PRECISION, allow_null=True, required=False
     # )
-
-    message = serializers.JSONField(write_only=True)
 
     favorite = serializers.NullBooleanField(read_only=True, required=False)


### PR DESCRIPTION
No need to serialize the raw message that generated a camera_media object (since it's not used in the frontend).  This will speed things up _a little_ bit, but not much.