### PR TITLE
feat(backend): prevent GEOSIntersects: TopologyException: side location conflict errors

### DIFF
--- a/server/safers/events/models.py
+++ b/server/safers/events/models.py
@@ -110,7 +110,8 @@ class Event(gis_models.Model):
         serial_number = f"S{self.sequence_number:0>5}"
 
         country = Country.objects.filter(
-            geometry__intersects=self.geometry_collection
+            # geometry__intersects=self.geometry_collection  # TODO: if geometry_collection is malformed can potentially get "GEOSIntersects: TopologyException: side location conflict"
+            geometry__intersects=self.center
         ).first()
 
         return "-".join(


### PR DESCRIPTION
This happens when the event.geometry_collection is somehow invalid.  I haven't figured out how that happens yet.  But using the alert.center instead of the complete geometry to work out which country it is in is probably good enough.