### PR TITLE
chore(backend): updated organization fixture

### DIFF
--- a/server/safers/users/fixtures/organizations_fixture.json
+++ b/server/safers/users/fixtures/organizations_fixture.json
@@ -1,72 +1,72 @@
 [
-{
-  "model": "users.organization",
-  "pk": "136eaf6a-95d1-40dd-93ed-97017109c530",
-  "fields": {
-    "organization_id": null,
-    "name": "PCF - Pau Costa Foundation",
-    "description": "",
-    "is_active": true
+  {
+    "model": "users.organization",
+    "pk": "136eaf6a-95d1-40dd-93ed-97017109c530",
+    "fields": {
+      "organization_id": null,
+      "name": "PCF - Pau Costa Foundation",
+      "description": "",
+      "is_active": false
+    }
+  },
+  {
+    "model": "users.organization",
+    "pk": "44571c35-9f70-46f3-b0fe-8ea98e9ec81d",
+    "fields": {
+      "organization_id": "1",
+      "name": "Test Organization",
+      "description": "This is a test organization",
+      "is_active": true
+    }
+  },
+  {
+    "model": "users.organization",
+    "pk": "45702a9f-cd4b-44db-a599-7ccc1e0be110",
+    "fields": {
+      "organization_id": null,
+      "name": "HRT - Hellenic Rescue Team",
+      "description": "",
+      "is_active": false
+    }
+  },
+  {
+    "model": "users.organization",
+    "pk": "8ed85a12-d8f1-4e4f-ba41-a5880ac97ac3",
+    "fields": {
+      "organization_id": null,
+      "name": "HMOD - Hellenic Republic Ministry of National Defence",
+      "description": "",
+      "is_active": false
+    }
+  },
+  {
+    "model": "users.organization",
+    "pk": "92604bfd-856a-468e-93d1-0f146650805e",
+    "fields": {
+      "organization_id": null,
+      "name": "SIS2B - Service d'Incendie et de Secours de la Haute Corse",
+      "description": "",
+      "is_active": false
+    }
+  },
+  {
+    "model": "users.organization",
+    "pk": "c6133d6f-ff1d-4beb-bad5-87e7d61ee2b2",
+    "fields": {
+      "organization_id": null,
+      "name": "CSI - Consorzio per il Sistema Informativo",
+      "description": "",
+      "is_active": false
+    }
+  },
+  {
+    "model": "users.organization",
+    "pk": "f4e84ec4-2b1f-4521-aaa5-215a923ce97c",
+    "fields": {
+      "organization_id": null,
+      "name": "CIMA - Fondazione CIMA",
+      "description": "",
+      "is_active": false
+    }
   }
-},
-{
-  "model": "users.organization",
-  "pk": "44571c35-9f70-46f3-b0fe-8ea98e9ec81d",
-  "fields": {
-    "organization_id": "1",
-    "name": "Test Organization",
-    "description": "This is a test organization",
-    "is_active": true
-  }
-},
-{
-  "model": "users.organization",
-  "pk": "45702a9f-cd4b-44db-a599-7ccc1e0be110",
-  "fields": {
-    "organization_id": null,
-    "name": "HRT - Hellenic Rescue Team",
-    "description": "",
-    "is_active": true
-  }
-},
-{
-  "model": "users.organization",
-  "pk": "8ed85a12-d8f1-4e4f-ba41-a5880ac97ac3",
-  "fields": {
-    "organization_id": null,
-    "name": "HMOD - Hellenic Republic Ministry of National Defence",
-    "description": "",
-    "is_active": true
-  }
-},
-{
-  "model": "users.organization",
-  "pk": "92604bfd-856a-468e-93d1-0f146650805e",
-  "fields": {
-    "organization_id": null,
-    "name": "SIS2B - Service d'Incendie et de Secours de la Haute Corse",
-    "description": "",
-    "is_active": true
-  }
-},
-{
-  "model": "users.organization",
-  "pk": "c6133d6f-ff1d-4beb-bad5-87e7d61ee2b2",
-  "fields": {
-    "organization_id": null,
-    "name": "CSI - Consorzio per il Sistema Informativo",
-    "description": "",
-    "is_active": true
-  }
-},
-{
-  "model": "users.organization",
-  "pk": "f4e84ec4-2b1f-4521-aaa5-215a923ce97c",
-  "fields": {
-    "organization_id": null,
-    "name": "CIMA - Fondazione CIMA",
-    "description": "",
-    "is_active": true
-  }
-}
 ]


### PR DESCRIPTION
organizations API already restricts response to active organizations; this just updates the fixture to ensure that all but the Test Organization is active.