### PR TITLE
feat(backend): restrict notifications by user

### DIFF
--- a/server/safers/notifications/tests/test_notifications.py
+++ b/server/safers/notifications/tests/test_notifications.py
@@ -5,8 +5,89 @@ from django.urls import resolve, reverse
 
 from rest_framework import status
 
+from safers.notifications.models import Notification, NotificationScopeChoices, NotificationRestrictionChoices
+
 from safers.core.tests.factories import *
+from safers.users.tests.factories import *
 from safers.notifications.tests.factories import *
+
+
+@pytest.mark.django_db
+class TestNotificationModels:
+    def test_filter_by_user(self):
+
+        user = UserFactory()
+        organization_1 = OrganizationFactory()
+        organization_2 = OrganizationFactory()
+        citizen_role = RoleFactory(name="citizen")
+        non_citizen_role = RoleFactory(name="professional")
+
+        unspecified_notification = NotificationFactory(
+            description="unspecified",
+            scope=None,
+            restriction=None,
+        )
+        public_notificiation = NotificationFactory(
+            description="public",
+            scope=NotificationScopeChoices.PUBLIC,
+            restriction=None,
+        )
+        restricted_citizen_notificiation = NotificationFactory(
+            description="restricted_citizen",
+            scope=NotificationScopeChoices.RESTRICTED,
+            restriction=NotificationRestrictionChoices.CITIZEN,
+        )
+        restricted_professional_notificiation = NotificationFactory(
+            description="restricted_professional",
+            scope=NotificationScopeChoices.RESTRICTED,
+            restriction=NotificationRestrictionChoices.PROFESSIONAL,
+        )
+        restricted_organization_notificiation = NotificationFactory(
+            description="restricted_organization",
+            scope=NotificationScopeChoices.RESTRICTED,
+            restriction=NotificationRestrictionChoices.ORGANIZATION,
+            target_organizations=[organization_1],
+        )
+
+        assert Notification.objects.count() == 5
+
+        public_qs = Notification.objects.filter_by_user(user)
+        assert public_qs.count() == 2
+        assert unspecified_notification in public_qs
+        assert public_notificiation in public_qs
+
+        user.role = citizen_role
+        user.save()
+        citizen_qs = Notification.objects.filter_by_user(user)
+        assert citizen_qs.count() == 3
+        assert unspecified_notification in citizen_qs
+        assert public_notificiation in citizen_qs
+        assert restricted_citizen_notificiation in citizen_qs
+
+        user.role = non_citizen_role
+        user.save()
+        professional_qs = Notification.objects.filter_by_user(user)
+        assert professional_qs.count() == 3
+        assert unspecified_notification in professional_qs
+        assert public_notificiation in professional_qs
+        assert restricted_professional_notificiation in professional_qs
+
+        user.organization = organization_2  # (note that this is the _wrong_ organization to match the query)
+        user.save()
+        organization_qs = Notification.objects.filter_by_user(user)
+        assert organization_qs.count() == 3
+        assert unspecified_notification in organization_qs
+        assert public_notificiation in organization_qs
+        assert restricted_professional_notificiation in organization_qs
+
+        user.organization = organization_1  # (note that this is the _right_ organization to match the query)
+        user.save()
+        organization_qs = Notification.objects.filter_by_user(user)
+        assert organization_qs.count() == 4
+        assert unspecified_notification in organization_qs
+        assert public_notificiation in organization_qs
+        assert restricted_professional_notificiation in organization_qs
+        assert restricted_organization_notificiation in organization_qs
 
 
 @pytest.mark.django_db

--- a/server/safers/notifications/views.py
+++ b/server/safers/notifications/views.py
@@ -18,6 +18,7 @@ from django_filters import rest_framework as filters
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 
+from safers.core.decorators import swagger_fake
 from safers.core.filters import DefaultFilterSetMixin, SwaggerFilterInspector, CaseInsensitiveChoiceFilter
 
 from safers.users.permissions import IsRemote
@@ -198,8 +199,9 @@ class NotificationViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [IsAuthenticated, IsRemote]
     serializer_class = NotificationSerializer
 
+    @swagger_fake(Notification.objects.none())
     def get_queryset(self):
-        queryset = Notification.objects.all()
+        queryset = Notification.objects.filter_by_user(self.request.user)
         return queryset.prefetch_related("geometries")
 
     def get_object(self):

--- a/server/safers/users/models/models_users.py
+++ b/server/safers/users/models/models_users.py
@@ -206,6 +206,14 @@ class User(AbstractUser):
         return self.auth_id is not None
 
     @property
+    def is_citizen(self):
+        return self.role and self.role.name == "citizen"
+
+    @property
+    def is_professional(self):
+        return self.role and self.role.name != "citizen"
+
+    @property
     def auth_user_data(self):
 
         try:

--- a/server/safers/users/tests/factories.py
+++ b/server/safers/users/tests/factories.py
@@ -79,7 +79,12 @@ class RoleFactory(factory.django.DjangoModelFactory):
         model = Role
 
     name = FactoryFaker("word")
+    label = FactoryFaker("word")
     description = optional_declaration(FactoryFaker("text"), chance=50)
+
+    @factory.lazy_attribute_sequence
+    def role_id(self, n):
+        return f"{n}"
 
 
 class OrganizationFactory(factory.django.DjangoModelFactory):
@@ -88,3 +93,7 @@ class OrganizationFactory(factory.django.DjangoModelFactory):
 
     name = FactoryFaker("word")
     description = optional_declaration(FactoryFaker("text"), chance=50)
+
+    @factory.lazy_attribute_sequence
+    def organization_id(self, n):
+        return f"{n}"


### PR DESCRIPTION
Added a filter method to restrict `Notifications` by user based on the `Notification's` `scope` & `restriction` & `target_organizations`.  Used that filter method in the  `NotificationViewSet.get_queryset` method.