### PR TITLE
feat(backend): made scope restrictions read-only

### DIFF
--- a/server/safers/notifications/serializers.py
+++ b/server/safers/notifications/serializers.py
@@ -41,7 +41,9 @@ class NotificationSerializer(serializers.ModelSerializer):
             "message",
         )
 
-    scopeRestriction = serializers.CharField(source="scope_restriction")
+    scopeRestriction = serializers.CharField(
+        source="scope_restriction", read_only=True
+    )
     target_organizations = serializers.SlugRelatedField(
         slug_field="organization_id",
         many=True,


### PR DESCRIPTION
Notification.scope_restriction is a property; therefore it's not required as serializer input.