### PR TITLE
feat(backend): ensured that any chatbot models created by the dashboard use correct start/end times

### DIFF
--- a/server/safers/chatbot/serializers/serializers_communications.py
+++ b/server/safers/chatbot/serializers/serializers_communications.py
@@ -3,6 +3,8 @@ from rest_framework_gis import serializers as gis_serializers
 
 from safers.users.models import Organization
 
+from safers.core.fields import UnderspecifiedDateTimeField
+
 from safers.chatbot.models import Communication
 from .serializers_base import ChatbotViewSerializer, ChatbotDateTimeFormats
 
@@ -67,11 +69,22 @@ class CommunicationCreateSerializer(gis_serializers.GeoFeatureModelSerializer):
         geo_field = "geometry"
         id_field = False
 
-    start = serializers.DateTimeField(
-        input_formats=ChatbotDateTimeFormats, write_only=True
+    start = UnderspecifiedDateTimeField(
+        input_formats=ChatbotDateTimeFormats,
+        write_only=True,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0,
     )
-    end = serializers.DateTimeField(
-        input_formats=ChatbotDateTimeFormats, write_only=True
+
+    end = UnderspecifiedDateTimeField(
+        input_formats=ChatbotDateTimeFormats,
+        write_only=True,
+        hour=23,
+        minute=59,
+        second=59,
+        microsecond=999999,
     )
 
     organizationIdList = serializers.SerializerMethodField(

--- a/server/safers/chatbot/serializers/serializers_missions.py
+++ b/server/safers/chatbot/serializers/serializers_missions.py
@@ -3,6 +3,8 @@ import json
 from rest_framework import serializers
 from rest_framework_gis import serializers as gis_serializers
 
+from safers.core.fields import UnderspecifiedDateTimeField
+
 from safers.chatbot.models import Mission, MissionStatusChoices
 from .serializers_base import ChatbotViewSerializer, ChatbotDateTimeFormats
 
@@ -79,11 +81,22 @@ class MissionCreateSerializer(gis_serializers.GeoFeatureModelSerializer):
         geo_field = "geometry"
         id_field = False
 
-    start = serializers.DateTimeField(
-        input_formats=ChatbotDateTimeFormats, write_only=True
+    start = UnderspecifiedDateTimeField(
+        input_formats=ChatbotDateTimeFormats,
+        write_only=True,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0,
     )
-    end = serializers.DateTimeField(
-        input_formats=ChatbotDateTimeFormats, write_only=True
+
+    end = UnderspecifiedDateTimeField(
+        input_formats=ChatbotDateTimeFormats,
+        write_only=True,
+        hour=23,
+        minute=59,
+        second=59,
+        microsecond=999999,
     )
 
     organizationId = serializers.SerializerMethodField(


### PR DESCRIPTION

The frontend only passes a date to the chatbot create serialiers; this PR ensures that the times are set correctly (ie: start is at 0:0:0 and end is at 23:59:59)