### PR TITLE
feat(backend): repalced timestamp of data layer

### DIFF
--- a/server/safers/data/views/views_datalayers.py
+++ b/server/safers/data/views/views_datalayers.py
@@ -301,7 +301,7 @@ class DataLayerView(views.APIView):
                         # "data_type": detail.get("dataTypeId"),
                         "id": f"{i}.{j}.{k}.{l}",
                         "title": layer["name"],
-                        "text": detail["created_At"],
+                        "text": next(iter(detail.get("timestamps") or []), None),
                         "units": layer.get("unitOfMeasure"),
                         "info": None,
                         "info_url": metadata_url.format(


### PR DESCRIPTION
Replaced what is displayed as the timestamp in the leaf-node of the DataLayer tree view; it was the date of creation of the layer, now it is the earliest date that the layer displays.