### PR TITLE
feat(backend): handle case where user has no organization in MapRequestView

### DIFF
--- a/server/safers/data/views/views_maprequests.py
+++ b/server/safers/data/views/views_maprequests.py
@@ -165,13 +165,13 @@ class MapRequestViewSet(
         return all MapRequests owned by this user / organization
         """
         current_user = self.request.user
-        if current_user.is_citizen:
-            queryset = current_user.map_requests.all()
-        else:
+        if current_user.is_professional:
             organization_users = current_user.organization.users.filter(
                 is_active=True
             )
             queryset = MapRequest.objects.filter(user__in=organization_users)
+        else:
+            queryset = current_user.map_requests.all()
 
         return queryset.prefetch_related("map_request_data_types")
 


### PR DESCRIPTION
Just in case the user had their organization accidentally set to null (which should no longer happen, but might still affect some pre-existing users), this code avoids checking their organization if they have no role when getting their MapRequests.