### PR TITLE
feat(backend): fixed some remaining errors w/ synchronizing a UserProfile

### DIFF
--- a/server/safers/users/views/views_oauth2.py
+++ b/server/safers/users/views/views_oauth2.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from collections import OrderedDict
 from sys import stdout
 
@@ -28,8 +29,6 @@ from safers.users.serializers import (
 )
 from safers.users.utils import AUTH_CLIENT, create_knox_token
 from safers.users.views import synchronize_profile, SynchronizeProfileDirection
-
-import logging
 
 logger = logging.getLogger(__name__)
 """
@@ -145,6 +144,7 @@ class LoginView(GenericAPIView):
                     )
             except Exception as e:
                 exception_message = "Unable to set profile fields on authentication server"
+                logger.error(exception_message)
                 return Response(
                     exception_message, status=status.HTTP_400_BAD_REQUEST
                 )

--- a/server/safers/users/views/views_profiles.py
+++ b/server/safers/users/views/views_profiles.py
@@ -35,10 +35,10 @@ def synchronize_profile(user_profile, direction):
 
     if direction == SynchronizeProfileDirection.REMOTE_TO_LOCAL:
         roles = Role.objects.filter(
-            name__in=profile_data.get("user", {}).get("roles")
+            name__in=(profile_data.get("user") or {}).get("roles", [])
         )
-        organizations = Organization.objects.filter(
-            organization_id=profile_data.get("organization", {}).get("id")
+        organizations = Organization.objects.active().filter(
+            organization_id=(profile_data.get("organization") or {}).get("id")
         )
         user_serializer = UserSerializer()
         user_serializer.update(


### PR DESCRIPTION
If a user didn't have an `organization` or `role` then those keys had the value `None`.  Therefore, this code:

```
profile_data.get("organization",{}).get("id")
```

was failing silently b/c it _would_ find the key "organization" and try to call `None.get("id")`.

Also, had to exclude inactive `organizations` from the query.

Also, added a bit of logging in case anything goes wrong in the future.