### PR TITLE
feat(backend): added backend support for long timeseries

### DIFF
--- a/server/safers/core/utils/__init__.py
+++ b/server/safers/core/utils/__init__.py
@@ -1,5 +1,6 @@
 from .utils_settings import DynamicSetting
 from .utils_enums import CaseInsensitiveTextChoices, SpaceInsensitiveTextChoices
 from .utils_geometry import cap_area_to_geojson
+from .utils_iter import chunk
 from .utils_urls import remove_urlpatterns, DateTimeConverter
 from .utils_validators import validate_reserved_words, validate_schema

--- a/server/safers/core/utils/utils_iter.py
+++ b/server/safers/core/utils/utils_iter.py
@@ -1,0 +1,6 @@
+def chunk(lst, chunk_size):
+    """
+    split lst into sublists of size chunk_size
+    """
+    for i in range(0, len(lst), chunk_size):
+        yield lst[i:i + chunk_size]


### PR DESCRIPTION
The GetTimeSeries request of geoserver can only cope w/ 100 timestamps and some of the subseasonal have many more.  This PR "chunks" them into subsets of 100 and passes an array of URLs for the frontend to query. The corresponding frontend work to merge the CSV returned by those queries together still needs to be done.