### PR TITLE
feat(backend): fixed the CameraMedia.triggers_alert algorithm

### DIFF
--- a/server/safers/cameras/models/models_cameramedia.py
+++ b/server/safers/cameras/models/models_cameramedia.py
@@ -207,8 +207,5 @@ class CameraMedia(gis_models.Model):
         ).last()
 
         return not most_recent_alerted_detected_camera_media or (
-            abs(
-                self.timestamp -
-                most_recent_alerted_detected_camera_media.timestamp
-            ) >= settings.SAFERS_DEFAULT_TIMERANGE
-        )
+            self.timestamp - most_recent_alerted_detected_camera_media.timestamp
+        ) >= settings.SAFERS_DEFAULT_TIMERANGE


### PR DESCRIPTION
Was incorrectly using the absolute value of the time difference between succesive CameraMedia objects.