### PR TITLE
feat(backend): changed image format of geoserver API calls

### DIFF
--- a/server/safers/data/views/views_datalayers.py
+++ b/server/safers/data/views/views_datalayers.py
@@ -210,7 +210,7 @@ class DataLayerView(views.APIView):
                     "transparent": True,
                     "width": width,  # max_resolution,
                     "height": height,  # max_resolution,
-                    "format": "image/png",
+                    "format": "image/jpeg",
                 },
                 safe="{}",
             )
@@ -229,7 +229,7 @@ class DataLayerView(views.APIView):
                     "tilematrix": WMTS_CRS + ":{{z}}",
                     "tilecol": "{{x}}",
                     "tilerow": "{{y}}",
-                    "format": "image/png",
+                    "format": "image/jpeg",
                 },
                 safe="{}",
             )

--- a/server/safers/data/views/views_maprequests.py
+++ b/server/safers/data/views/views_maprequests.py
@@ -240,7 +240,7 @@ class MapRequestViewSet(
                     "transparent": True,
                     "width": width,
                     "height": height,
-                    "format": "image/png",
+                    "format": "image/jpeg",
                 },
                 safe="{}",
             )
@@ -259,7 +259,7 @@ class MapRequestViewSet(
                     "tilematrix": self.WMTS_CRS + ":{{z}}",
                     "tilecol": "{{x}}",
                     "tilerow": "{{y}}",
-                    "format": "image/png",
+                    "format": "image/jpeg",
                 },
                 safe="{}",
             )


### PR DESCRIPTION
Switched from "png" to "jpeg" for geoserer API calls (for both GetMap & GetTile). These return smaller images more quickly.