### PR TITLE
feat(backend): ensured alerts have a default status

### DIFF
--- a/server/safers/alerts/models.py
+++ b/server/safers/alerts/models.py
@@ -283,7 +283,7 @@ class Alert(models.Model):
         try:
             with transaction.atomic():
                 message_timestamp = message_body.get("sent")
-                message_status = message_body.get("status")
+                message_status = message_body.get("status", "Actual")
                 message_source = message_body.get("source")
                 if message_source:
                     message_source = AlertSource.find_enum(message_source)


### PR DESCRIPTION
Having already ensured that alerts created automatically when a fire is detected by a camera have a default status, this PR does the same for alerts created via DSS.