### PR TITLE
feat(backend): fixed invalid JSON error when parsing camera media messages w/ location_info

### DIFF
--- a/server/safers/cameras/utils.py
+++ b/server/safers/cameras/utils.py
@@ -55,9 +55,7 @@ def process_messages(message_body, **kwargs):
             ).values_list("name", flat=True)
             geometry_details = message_body.get("fire_location", {})
             lon, lat = (geometry_details.get("longitude"), geometry_details.get("latitude"))
-            geometry_details.update({
-                "geometry": geos.Point(lon, lat) if lon and lat else None
-            })
+            geometry = geos.Point(lon, lat) if lon and lat else None
 
             serializer = CameraMediaSerializer(
                 data={
@@ -78,7 +76,7 @@ def process_messages(message_body, **kwargs):
                     "direction":
                         geometry_details.get("direction") or camera.direction,
                     "geometry":
-                        geometry_details.get("geometry") or camera.geometry,
+                        geometry or camera.geometry,
                     "message":
                         message_body,
                 }


### PR DESCRIPTION
When determining the geometry for a camera media object I added a geos object into the message body to use later.  Unfortunately, that object is invalid JSON when it comes time to parse the message again in case I have to create an alert.

To fix this I create the geos object separately from the message body.