### PR TITLE
feat(backend): remove special case for DataType 35006

### DIFF
--- a/server/safers/data/models/models_maprequests.py
+++ b/server/safers/data/models/models_maprequests.py
@@ -334,11 +334,8 @@ class MapRequest(gis_models.Model):
         try:
 
             for data_type in self.data_types.all():
-                # TODO: DO SOMETHING SPECIAL FOR CIMA
-                if data_type.id == "35006":  # do something special for CIMA
-                    pass
-                routing_key = f"request.{data_type.datatype_id}.{RMQ_USER}.{self.request_id}"
 
+                routing_key = f"request.{data_type.datatype_id}.{RMQ_USER}.{self.request_id}"
                 message_body["datatype_id"] = data_type.datatype_id
 
                 rmq.publish(


### PR DESCRIPTION
DataType 35006 is no longer needed for "Wildfire Simulation" MapRequests.  It was always associated w/ _creating_ a request and never w/ any of the resultant request layers.  Therefore there was some code to treat it specially.  This PR removes that code since it will no longer form part of the MapRequest - it will be removed from both the backend database and the frontend form.