### PR TITLE
Prevent duplicate favorite items

### DIFF
--- a/server/safers/alerts/views.py
+++ b/server/safers/alerts/views.py
@@ -97,7 +97,7 @@ class AlertFilterSet(DefaultFilterSetMixin, filters.FilterSet):
     source = CaseInsensitiveChoiceFilter(choices=AlertSource.choices)
 
     order = MultiFieldOrderingFilter(
-        fields=(("timestamp", "date"), ), multi_fields=["favorite"]
+        fields=(("timestamp", "date"), ), multi_fields=["-favorite"]
     )
 
     start_date = filters.DateFilter(

--- a/server/safers/cameras/views/views_cameramedia.py
+++ b/server/safers/cameras/views/views_cameramedia.py
@@ -56,7 +56,7 @@ class CameraMediaFilterSet(DefaultFilterSetMixin, filters.FilterSet):
         }
 
     order = MultiFieldOrderingFilter(
-        fields=(("timestamp", "date"), ), multi_fields=["favorite"]
+        fields=(("timestamp", "date"), ), multi_fields=["-favorite"]
     )
 
     type = CaseInsensitiveChoiceFilter(choices=CameraMediaType.choices)

--- a/server/safers/events/views.py
+++ b/server/safers/events/views.py
@@ -82,7 +82,7 @@ class EventFilterSet(DefaultFilterSetMixin, filters.FilterSet):
         fields = {}
 
     order = MultiFieldOrderingFilter(
-        fields=(("start_date", "date"), ), multi_fields=["favorite"]
+        fields=(("start_date", "date"), ), multi_fields=["-favorite"]
     )
 
     status = filters.MultipleChoiceFilter(


### PR DESCRIPTION
Changed the way that favorites are handled in the views for `alerts`, `events`, and `camera_medias`.  

Previously, I was trying to be fancy and annotate the querysets based on a reverse fk lookup.  While this worked, I couldn't then eliminate duplicates without changing the default ordering.  It also was a bit inefficient b/c it issued multiple db hits.   Instead I reverted to the less-fancy but recommended way (as per [here](https://docs.djangoproject.com/en/4.1/ref/models/querysets/#in)}:

1. Build a queryset of all items (0 db queries b/c of lazy loading)
2. Compute a user's favorite items and save that in a list (1 db query)
3. Add an annotation to the queryset on whether or not each item is in that list (still 0 db queries)
4. Order the queryset by that annotation (still 0 db queries)
5. Return the queryset (_finally_ 1 db query)

I also had to update the way that the existing ordering filter worked.  A client can specify an `?order=` URL parameter to order the items.  But I always wanted favorite items to appear first _regardless of what that URL parameter said_.  The annotation from step **3** above was slightly different than the one in the old code; it was descending rather then ascending, so I just had to add a "-" to the bit of my filtering code that tacked on the default "favorite" order to any additional order specified in URL parameters.