### PR TITLE
feat(backend): prevent updating all user fields

### DIFF
--- a/server/safers/users/serializers/__init__.py
+++ b/server/safers/users/serializers/__init__.py
@@ -6,7 +6,7 @@ from .serializers_oauth2 import (
     RegisterViewSerializer as Oauth2RegisterViewSerializer,
     Oauth2UserSerializer,
 )
-from .serializers_users import UserSerializer, UserSerializerLite
+from .serializers_users import UserSerializerLite, UserSerializer, ReadOnlyUserSerializer
 from .serializers_auth import (
     JWTSerializer,
     LoginSerializer,

--- a/server/safers/users/serializers/serializers_users.py
+++ b/server/safers/users/serializers/serializers_users.py
@@ -134,3 +134,24 @@ class UserSerializer(UserSerializerLite):
     #     profile = profile_serializer.create(profile_data)
     #     user = User.objects.create(profile=profile, **validated_data)
     #     return user
+
+
+class ReadOnlyUserSerializer(UserSerializer):
+    """
+    A serializer that doesn't allow modifying organization or role
+    """
+    class Meta:
+        model = User
+        fields = UserSerializer.Meta.fields
+
+    organization = serializers.PrimaryKeyRelatedField(
+        required=False,
+        allow_null=True,
+        read_only=True,
+    )
+
+    role = serializers.PrimaryKeyRelatedField(
+        required=False,
+        allow_null=True,
+        read_only=True,
+    )


### PR DESCRIPTION
When editing a `UserProfile` in the frontend users can currently change their `organization` and `role`.  Passing this onto the proxy API (which in turn calls **FusionAuth**) causes errors.  And, anyway, it doesn't make sense to allow a user to change their `organization` or to change their (_own_) `role`.

This PR adds a new serializer to use when updating a user.  The fields are the same (so that the content passed to the proxy API has the same structure).  But updating the `organization` and role is `disabled`; those are read-only fields.

To avoid confusion, the ability to modify these fields in the frontend UserProfile Form should also be disabled.