### PR TITLE
feat(backend): Add new cameras & exclude inactive cameras from views

### DIFF
--- a/server/safers/cameras/fixtures/cameras_fixture.json
+++ b/server/safers/cameras/fixtures/cameras_fixture.json
@@ -184,7 +184,7 @@
   {
     "model": "cameras.camera",
     "fields": {
-      "is_active": true,
+      "is_active": false,
       "camera_id": "HRT_Mt_Chortiatis_116",
       "name": "Mt_Chortiatis",
       "model": "reolink RLC-823A",
@@ -198,7 +198,7 @@
   {
     "model": "cameras.camera",
     "fields": {
-      "is_active": true,
+      "is_active": false,
       "camera_id": "HRT_Mt_Chortiatis_139",
       "name": "Mt_Chortiatis",
       "model": "reolink RLC-823A",
@@ -207,6 +207,90 @@
       "geometry": "SRID=4326;POINT (23.068407 40.620997)",
       "direction": 139,
       "altitude": 492
+    }
+  },
+  {
+    "model": "cameras.camera",
+    "fields": {
+      "is_active": true,
+      "camera_id": "HRT_Mt_Chortiatis_141",
+      "name": "Mt_Chortiatis",
+      "model": "reolink RLC-823A",
+      "owner": "HRT",
+      "nation": "Greece",
+      "geometry": "SRID=4326;POINT (23.056003 40.633228)",
+      "direction": 141,
+      "altitude": 725
+    }
+  },
+  {
+    "model": "cameras.camera",
+    "fields": {
+      "is_active": true,
+      "camera_id": "HRT_Mt_Chortiatis_182",
+      "name": "Mt_Chortiatis",
+      "model": "reolink RLC-823A",
+      "owner": "HRT",
+      "nation": "Greece",
+      "geometry": "SRID=4326;POINT (23.056003 40.633228)",
+      "direction": 182,
+      "altitude": 725
+    }
+  },
+  {
+    "model": "cameras.camera",
+    "fields": {
+      "is_active": true,
+      "camera_id": "HRT_Mt_Chortiatis_206",
+      "name": "Mt_Chortiatis",
+      "model": "reolink RLC-823A",
+      "owner": "HRT",
+      "nation": "Greece",
+      "geometry": "SRID=4326;POINT (23.056003 40.633228)",
+      "direction": 206,
+      "altitude": 725
+    }
+  },
+  {
+    "model": "cameras.camera",
+    "fields": {
+      "is_active": true,
+      "camera_id": "HRT_Mt_Chortiatis_231",
+      "name": "Mt_Chortiatis",
+      "model": "reolink RLC-823A",
+      "owner": "HRT",
+      "nation": "Greece",
+      "geometry": "SRID=4326;POINT (23.056003 40.633228)",
+      "direction": 231,
+      "altitude": 725
+    }
+  },
+  {
+    "model": "cameras.camera",
+    "fields": {
+      "is_active": true,
+      "camera_id": "HRT_Mt_Chortiatis_259",
+      "name": "Mt_Chortiatis",
+      "model": "reolink RLC-823A",
+      "owner": "HRT",
+      "nation": "Greece",
+      "geometry": "SRID=4326;POINT (23.056003 40.633228)",
+      "direction": 259,
+      "altitude": 725
+    }
+  },
+  {
+    "model": "cameras.camera",
+    "fields": {
+      "is_active": true,
+      "camera_id": "HRT_Mt_Chortiatis_272",
+      "name": "Mt_Chortiatis",
+      "model": "reolink RLC-823A",
+      "owner": "HRT",
+      "nation": "Greece",
+      "geometry": "SRID=4326;POINT (23.056003 40.633228)",
+      "direction": 272,
+      "altitude": 725
     }
   }
 ]

--- a/server/safers/cameras/models/models_cameramedia.py
+++ b/server/safers/cameras/models/models_cameramedia.py
@@ -69,6 +69,12 @@ class CameraMediaQuerySet(models.QuerySet):
     def unalerted(self):
         return self.filter(alert__isnull=True)
 
+    def active(self):
+        return self.filter(camera__is_active=True)
+
+    def inactive(self):
+        return self.filter(camera__is_active=False)
+
 
 class CameraMediaFireClass(models.Model):
     class Meta:

--- a/server/safers/cameras/views/views_cameramedia.py
+++ b/server/safers/cameras/views/views_cameramedia.py
@@ -185,7 +185,9 @@ class CameraMediaViewSet(
             "id", flat=True
         )
 
-        qs = CameraMedia.objects.all().prefetch_related("tags", "fire_classes")
+        qs = CameraMedia.objects.active().prefetch_related(
+            "tags", "fire_classes"
+        )
         qs = qs.annotate(
             favorite=ExpressionWrapper(
                 Q(id__in=favorite_camera_meda_ids),


### PR DESCRIPTION
The set of active `Cameras` has been updated, so I updated the fixture file accordingly.  That file will have to be re-loaded in each environment.

I kept the old inactive `Cameras`, in case there were any images/alerts/whatever associated with them.  But I updated the `CameraMedia` View to exclude images from inactive `Cameras`.  (The images are still in the db - until they get automatically purged - they just aren't visible in the **dashboard** at this time.)