### PR TITLE
feat(backend): added local fusionauth service

### DIFF
--- a/auth/config/.gitignore
+++ b/auth/config/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/auth/kickstart/json/roles.json
+++ b/auth/kickstart/json/roles.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "administrator",
+    "description": "Administrator of SAFERS",
+    "isDefault": false,
+    "isSuperRole": true
+  },
+  {
+    "name": "citizen",
+    "description": "citizen",
+    "isDefault": true,
+    "isSuperRole": false
+  },
+  {
+    "name": "decision_maker",
+    "description": "Decision Maker: sits in a control rooms during emergency, monitoring the situation",
+    "isDefault": false,
+    "isSuperRole": false
+  },
+  {
+    "name": "first_responder",
+    "description": "On-field role: First Responders can make reports and accomplish missions",
+    "isDefault": false,
+    "isSuperRole": false
+  },
+  {
+    "name": "organization_manager",
+    "description": "Organization Manager: manages everything within his/her Organization in SAFERS",
+    "isDefault": false,
+    "isSuperRole": false
+  },
+  {
+    "name": "team_leader",
+    "description": "Like First Responder, but with more powers",
+    "isDefault": false,
+    "isSuperRole": false
+  }
+]

--- a/auth/kickstart/kickstart.json
+++ b/auth/kickstart/kickstart.json
@@ -1,0 +1,71 @@
+{
+  "variables": {
+    "apiKey": "#{ENV.FUSIONAUTH_API_KEY}",
+    "adminEmail": "#{ENV.FUSIONAUTH_ADMIN_EMAIL}",
+    "adminPassword": "#{ENV.FUSIONAUTH_ADMIN_PASSWORD}",
+    "applicationId": "#{ENV.FUSIONAUTH_APPLICATION_ID}",
+    "clientId": "#{ENV.FUSIONAUTH_CLIENT_ID}",
+    "clientSecret": "#{ENV.FUSIONAUTH_CLIENT_SECRET}",
+    "defaultApplicationId": "3c219e58-ed0e-4b18-ad48-f4f92793ae32",
+    "defaultThemeId": "75a068fd-e94b-451a-9aeb-3ddb9a3b5987",
+    "defaultTenantId": "30663132-6464-6665-3032-326466613934",
+    "tenantId": "#{ENV.FUSIONAUTH_TENANT_ID}",
+    "tenantName": "#{ENV.FUSIONAUTH_TENANT_NAME}",
+    "redirectURL": "#{ENV.FUSIONAUTH_REDIRECT_URL}"
+  },
+  "apiKeys": [
+    {
+      "key": "#{apiKey}",
+      "description": "default safers key"
+    }
+  ],
+  "requests": [
+    {
+      "method": "POST",
+      "url": "/api/tenant/#{tenantId}",
+      "body": {
+        "sourceTenantId": "#{defaultTenantId}",
+        "tenant": {
+          "name": "#{tenantName}"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/application/#{applicationId}",
+      "sourceApplicationId": "#{defaultApplicationId}",
+      "tenantId": "#{tenantId}",
+      "body": {
+        "application": {
+          "name": "safers",
+          "oauthConfiguration": {
+            "authorizedOriginURLs": [],
+            "authorizedRedirectURLs": ["#{redirectURL}"],
+            "clientSecret": "#{clientSecret}",
+            "enabledGrants": ["authorization_code", "password", "refresh_token"],
+            "generateRefreshToken": true
+          },
+          "registrationConfiguration": {
+            "confirmPassword": true,
+            "enabled": true
+          },
+          "roles": "&{json/roles.json}"
+        }
+      }
+    },
+    {
+      "method": "POST",
+      "url": "/api/user/registration/",
+      "body": {
+        "user": {
+          "email": "#{adminEmail}",
+          "password": "#{adminPassword}"
+        },
+        "registration": {
+          "applicationId": "#{FUSIONAUTH_APPLICATION_ID}",
+          "roles": ["admin"]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Added an instance of FusionAuth to use w/ docker-compose during development.  Unfortunately, this isn't much use when actually running the dashboard because all the other safers comoponents (chatbot, gateway, etc.) require token authentication against the _real_ FusionAuth instance.