### PR TITLE
feat(backend): get child organizations along with parents

### DIFF
--- a/server/safers/chatbot/views/views_communications.py
+++ b/server/safers/chatbot/views/views_communications.py
@@ -69,11 +69,11 @@ class CommunicationListView(CommunicationView):
                 # source= (source has a default value so no need to parse from proxy_data)
                 scope=data.get("scope"),
                 restriction=data.get("restriction"),
-                source_organization=Organization.objects.safe_get(name=data.get("organizationName")),
+                source_organization=Organization.objects.get(name=data.get("organizationName")),
                 target_organizations=filter(
                     None,
                     [
-                        Organization.objects.safe_get(organization_id=organization_id)
+                        Organization.objects.get(id=organization_id)
                         for organization_id in data.get("organizationIdList") or []
                     ]
                 ),

--- a/server/safers/core/clients.py
+++ b/server/safers/core/clients.py
@@ -73,7 +73,21 @@ class GatewayClient(object):
             timeout=timeout,
         )
         response.raise_for_status()
-        return response.json()
+
+        # follow all parent organizations...
+        organizations_data = response.json()["data"]
+        for organization in organizations_data:
+            if organization["hasChildren"]:
+                organizations_data += self.get_organizations(
+                    params=dict(
+                        parentId=organization["id"],
+                        **default_params,
+                    ),
+                    auth=auth,
+                    timeout=timeout,
+                )
+
+        return organizations_data
 
     def get_layers(
         self, params=None, auth=None, timeout=REQUEST_TIMEOUT

--- a/server/safers/users/models/models_organizations.py
+++ b/server/safers/users/models/models_organizations.py
@@ -17,8 +17,7 @@ class OrganizationManager(CachedTransientModelManager):
     cache_key = "organizations"
 
     def get_transient_queryset_data(self):
-        response = GATEWAY_CLIENT.get_organizations(timeout=10)
-        organizations_data = response["data"]
+        organizations_data = GATEWAY_CLIENT.get_organizations(timeout=10)
 
         # organizations_data = MOCK_ORGANIZATIONS_DATA
 


### PR DESCRIPTION
Organizations are split up into parents and children.  This is in order to allow chatbot users to interact w/ multiple organizations at once. For the dashboard, we just need to make sure that _all_ organizations are available to **1)** register as and **2)** cross-check chatbot artefacts against.  This PR extends the `get_organizations` method to include all child organizations in that list.

This PR also extends `TransientModelQuerySet` to include filter & exclude methods in case I ever want to do anything like

```
Organization.objects.filter(hasChildren=False)
```