### PR TITLE
feat(backend): allow missing organizations during registration

### DIFF
--- a/server/safers/auth/utils.py
+++ b/server/safers/auth/utils.py
@@ -1,4 +1,4 @@
-from rest_framework.settings import settings as drf_settings
+from rest_framework.settings import api_settings as drf_settings
 
 
 def reshape_auth_errors(auth_error_response):

--- a/server/safers/auth/views/views_auth.py
+++ b/server/safers/auth/views/views_auth.py
@@ -68,10 +68,10 @@ class RegisterView(GenericAPIView):
         )
         serializer.is_valid(raise_exception=True)
 
-        organization = serializer.validated_data.pop("organization")
+        organization = serializer.validated_data.pop("organization", None)
         team = None  # TODO: CANNOT SET TEAM IN DASHBOARD YET
-        role = serializer.validated_data.pop("role")
-        accepted_terms = serializer.validated_data.pop("accepted_terms")
+        role = serializer.validated_data.pop("role", None)
+        accepted_terms = serializer.validated_data.pop("accepted_terms", False)
 
         # register w/ FusionAuth...
         auth_response = AUTH_CLIENT.register({


### PR DESCRIPTION
Organization is already an optional serializer field.  But the view still tried to access it from the validated_data w/ no default value.  This PR adds a default value of `None` (for organizations as well as roles)

This PR also fixes a bug where the wrong module was imported when rendering errors from FusionAuth.