### PR TITLE
feat(backend): propagate profile updates to gateway

### DIFF
--- a/server/safers/core/generics.py
+++ b/server/safers/core/generics.py
@@ -1,0 +1,52 @@
+"""
+Concrete generic views that do everything the standard DRF views do except for
+patch / partial_update
+"""
+from rest_framework import generics, mixins
+
+
+class PatchlessUpdateModelMixin(object):
+    """
+    exposes an update (put) but not a partial_update (patch)
+    """
+    def update(self, request, *args, **kwargs):
+        return mixins.UpdateModelMixin.update(self, request, *args, **kwargs)
+
+    def perform_update(self, serializer):
+        serializer.save()
+
+
+class PatchlessUpdateAPIView(
+    PatchlessUpdateModelMixin,
+    generics.GenericAPIView,
+):
+    def put(self, request, *args, **kwargs):
+        return self.update(request, *args, **kwargs)
+
+
+class RetrievePatchlessUpdateAPIView(
+    mixins.RetrieveModelMixin,
+    PatchlessUpdateModelMixin,
+    generics.GenericAPIView,
+):
+    def get(self, request, *args, **kwargs):
+        return self.retrieve(request, *args, **kwargs)
+
+    def put(self, request, *args, **kwargs):
+        return self.update(request, *args, **kwargs)
+
+
+class RetrievePatchlessUpdateDestroyAPIView(
+    mixins.RetrieveModelMixin,
+    PatchlessUpdateModelMixin,
+    mixins.DestroyModelMixin,
+    generics.GenericAPIView,
+):
+    def get(self, request, *args, **kwargs):
+        return self.retrieve(request, *args, **kwargs)
+
+    def put(self, request, *args, **kwargs):
+        return self.update(request, *args, **kwargs)
+
+    def delete(self, request, *args, **kwargs):
+        return self.destroy(request, *args, **kwargs)

--- a/server/safers/users/permissions.py
+++ b/server/safers/users/permissions.py
@@ -1,6 +1,12 @@
 from rest_framework.permissions import BasePermission
 
 
+class IsSelf(BasePermission):
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        return user == obj
+
+
 class IsSelfOrAdmin(BasePermission):
     def has_object_permission(self, request, view, obj):
         user = request.user


### PR DESCRIPTION
When updating a user profile, synchronise those changes w/ the gateway as well.

Also defined a custom mixin to restrict updates to PUTs and not PATCHes.