### PR TITLE
feat(backend): improve the speed of CameraMediaViewSet

### DIFF
--- a/server/safers/cameras/views/views_cameramedia.py
+++ b/server/safers/cameras/views/views_cameramedia.py
@@ -130,13 +130,12 @@ class CameraMediaViewSet(
         """
         ensures that favorite camera_medias are at the start of the qs
         """
+        qs = CameraMedia.objects.active(
+        ).select_related("camera").prefetch_related("tags", "fire_classes")
+
         user = self.request.user
         favorite_camera_meda_ids = user.favorite_camera_medias.values_list(
             "id", flat=True
-        )
-
-        qs = CameraMedia.objects.active().prefetch_related(
-            "tags", "fire_classes"
         )
         qs = qs.annotate(
             favorite=ExpressionWrapper(


### PR DESCRIPTION
Improved the speed of `CameraMediaViewSet` by calling `select_related` on the queryset to prevent the dreaded "N+1" problem.