### PR TITLE
feat(backend): renamed cameramedia url to remote_url

### DIFF
--- a/server/safers/cameras/admin/admin_cameramedia.py
+++ b/server/safers/cameras/admin/admin_cameramedia.py
@@ -56,7 +56,7 @@ class CameraMediaAdmin(gis_admin.GeoModelAdmin):
         "created",
         "modified",
         "description",
-        "url",
+        "remote_url",
         "media",
         "thumbnail",
         "type",
@@ -122,7 +122,7 @@ class CameraMediaAdmin(gis_admin.GeoModelAdmin):
 
     @admin.display(
         description=
-        "Copy selected Camera Media URLS to files and create thumbnails"
+        "Copy selected Camera Media Remote URLS to files and create thumbnails"
     )
     def copy_urls(self, request, queryset):
 
@@ -130,14 +130,14 @@ class CameraMediaAdmin(gis_admin.GeoModelAdmin):
 
             try:
                 camera_media.copy_url_to_media(
-                    camera_media.url, camera_media.media
+                    camera_media.remote_url, camera_media.media
                 )
                 camera_media.copy_media_to_thumbnail(
                     camera_media.media.file, camera_media.thumbnail
                 )
-                msg = f"copied {camera_media.id} URL to {camera_media.media} and {camera_media.thumbnail}."
+                msg = f"copied {camera_media.id} Remote URL to {camera_media.media} and {camera_media.thumbnail}."
                 self.message_user(request, msg, messages.SUCCESS)
 
             except Exception as e:
-                msg = f"error copying {camera_media.id} URL: {e}"
+                msg = f"error copying {camera_media.id} Remote URL: {e}"
                 self.message_user(request, msg, messages.ERROR)

--- a/server/safers/cameras/migrations/0017_rename_cameramedia_file_url.py
+++ b/server/safers/cameras/migrations/0017_rename_cameramedia_file_url.py
@@ -15,4 +15,9 @@ class Migration(migrations.Migration):
             old_name='file',
             new_name='media',
         ),
+        migrations.RenameField(
+            model_name='cameramedia',
+            old_name='url',
+            new_name='remote_url',
+        ),
     ]

--- a/server/safers/cameras/migrations/0018_cameramedia_thumbnail_alter_cameramedia_type.py
+++ b/server/safers/cameras/migrations/0018_cameramedia_thumbnail_alter_cameramedia_type.py
@@ -7,18 +7,27 @@ import safers.cameras.models.models_cameramedia
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cameras', '0017_rename_file_cameramedia_media'),
+        ('cameras', '0017_rename_cameramedia_file_url'),
     ]
 
     operations = [
         migrations.AddField(
             model_name='cameramedia',
             name='thumbnail',
-            field=models.ImageField(blank=True, null=True, upload_to=safers.cameras.models.models_cameramedia.camera_media_file_path),
+            field=models.ImageField(
+                blank=True,
+                null=True,
+                upload_to=safers.cameras.models.models_cameramedia.
+                camera_media_file_path
+            ),
         ),
         migrations.AlterField(
             model_name='cameramedia',
             name='type',
-            field=models.CharField(choices=[('IMAGE', 'Image'), ('VIDEO', 'Video')], help_text='What type of media is this?', max_length=64),
+            field=models.CharField(
+                choices=[('IMAGE', 'Image'), ('VIDEO', 'Video')],
+                help_text='What type of media is this?',
+                max_length=64
+            ),
         ),
     ]

--- a/server/safers/cameras/models/models_cameramedia.py
+++ b/server/safers/cameras/models/models_cameramedia.py
@@ -124,7 +124,7 @@ class CameraMedia(gis_models.Model):
 
     description = models.TextField(blank=True, null=True)
 
-    url = models.URLField(
+    remote_url = models.URLField(
         max_length=512, blank=True, null=True
     )  # pre-signed AWS URLs can be quite long, hence the max_length kwarg
 
@@ -271,8 +271,8 @@ class CameraMedia(gis_models.Model):
         retval = super().save(**kwargs)
 
         try:
-            if self.url and not self.media:
-                CameraMedia.copy_url_to_media(self.url, self.media)
+            if self.remote_url and not self.media:
+                CameraMedia.copy_url_to_media(self.remote_url, self.media)
             if self.media and not self.thumbnail:
                 CameraMedia.copy_media_to_thumbnail(
                     self.media.file, self.thumbnail

--- a/server/safers/cameras/serializers/serializers_cameramedia.py
+++ b/server/safers/cameras/serializers/serializers_cameramedia.py
@@ -18,7 +18,7 @@ class CameraMediaSerializer(serializers.ModelSerializer):
             "direction",
             "distance",
             "geometry",
-            "url",
+            "remote_url",
             "media_url",
             "thumbnail_url",
             "favorite",  # note "favorite" is an annotated field

--- a/server/safers/cameras/tests/factories.py
+++ b/server/safers/cameras/tests/factories.py
@@ -47,7 +47,7 @@ class CameraMediaFactory(factory.django.DjangoModelFactory):
         "date_time_between", start_date=timezone.now() - timedelta(days=1)
     )  # default timestamp is recent enough to match default filters
     description = optional_declaration(FactoryFaker("text"), chance=50)
-    url = FactoryFaker("uri")
+    remote_url = FactoryFaker("uri")
     # direction = None
     # distance = None
     # geometry = None

--- a/server/safers/cameras/utils.py
+++ b/server/safers/cameras/utils.py
@@ -65,7 +65,7 @@ def process_messages(message_body, **kwargs):
                         CameraMediaType.IMAGE,
                     "timestamp":
                         message_body["timestamp"],
-                    "url":
+                    "remote_url":
                         message_body["link"],
                     "fire_classes":
                         fire_classes,
@@ -123,7 +123,7 @@ def process_messages(message_body, **kwargs):
                             "properties": {},
                             "geometry": json.loads(camera.geometry.json)
                         }],
-                        "media": [camera_media.url],
+                        "media": [camera_media.remote_url],
                         "message": message_body,
                     }
                 )


### PR DESCRIPTION
Renamed CameraMedia.url to CameraMedia.remote_url to better reflect that this is the original "remote" URL that is only used as a fallback attribute in case there was a problem copying it to our "local" S3 bucket.