### PR TITLE
feat(backend): update storage backends

### DIFF
--- a/server/config/settings/deployment.py
+++ b/server/config/settings/deployment.py
@@ -29,8 +29,14 @@ INSTALLED_APPS += []
 # Using Bucketeer to allow Heroku to manage storage in AWS S3.  PublicMediaS3Storage is
 # used by default; I can also specify PrivateMediaS3Storage on a field-by-field basis.
 
-STATICFILES_STORAGE = "safers.core.storage.StaticS3Storage"
-DEFAULT_FILE_STORAGE = "safers.core.storage.PublicMediaS3Storage"
+STORAGES = {
+    "default": {
+        "BACKEND": "safers.core.storage.PublicMediaS3Storage"
+    },
+    "staticfiles": {
+        "BACKEND": "safers.core.storage.StaticS3Storage"
+    },
+}
 
 AWS_ACCESS_KEY_ID = env("BUCKETEER_AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = env("BUCKETEER_AWS_SECRET_ACCESS_KEY")

--- a/server/config/settings/development.py
+++ b/server/config/settings/development.py
@@ -25,8 +25,14 @@ CORS_ORIGIN_ALLOW_ALL = True
 # static & media files #
 ########################
 
-STATICFILES_STORAGE = "safers.core.storage.LocalStaticStorage"
-DEFAULT_FILE_STORAGE = "safers.core.storage.LocalMediaStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "safers.core.storage.LocalMediaStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "safers.core.storage.LocalStaticStorage",
+    }
+}
 
 STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "_static"


### PR DESCRIPTION
As of Django 4.2 the method of specifying storage backends has changed; Therefore I need to update settings in order to use S3 storages in deployment.